### PR TITLE
Fix broken ivpm_popen call

### DIFF
--- a/src/pytest_fv/console.py
+++ b/src/pytest_fv/console.py
@@ -23,6 +23,7 @@ import asyncio
 import subprocess
 import sys
 import ivpm
+from ivpm import ivpm_subprocess
 
 class Console(object):
 
@@ -55,7 +56,7 @@ class Console(object):
                 print("process_exited")
                 pass
 
-        proc = ivpm.ivpm_popen(
+        proc = ivpm_subprocess.ivpm_popen(
             cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,


### PR DESCRIPTION
Newer versions of ivpm don't export `ivpm_popen` in the module's main namespace. This causes the unit tests in pyhdl-if to break because `ivpm.ivpm_popen` can't be found. This allows those tests to run.